### PR TITLE
feat: add URL suffix to files of specified type

### DIFF
--- a/src/main/java/run/halo/s3os/S3OsProperties.java
+++ b/src/main/java/run/halo/s3os/S3OsProperties.java
@@ -1,6 +1,10 @@
 package run.halo.s3os;
 
+import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
@@ -38,6 +42,16 @@ class S3OsProperties {
 
 
     private String region = "Auto";
+
+    private List<urlSuffixItem> urlSuffixes;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class urlSuffixItem {
+        private String fileSuffix;
+        private String urlSuffix;
+    }
 
     public String getObjectName(String filename) {
         var objectName = filename;

--- a/src/main/java/run/halo/s3os/UrlUtils.java
+++ b/src/main/java/run/halo/s3os/UrlUtils.java
@@ -2,6 +2,7 @@ package run.halo.s3os;
 
 import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 public class UrlUtils {
     private static final List<String> HTTP_PREFIXES = Arrays.asList("http://", "https://");
@@ -16,5 +17,22 @@ public class UrlUtils {
             }
         }
         return url;
+    }
+
+    public static String findUrlSuffix(List<S3OsProperties.urlSuffixItem> urlSuffixList,
+                                       String fileName) {
+        if (StringUtils.isBlank(fileName)) {
+            return null;
+        }
+        fileName = fileName.toLowerCase();
+        for (S3OsProperties.urlSuffixItem item : urlSuffixList) {
+            String[] fileSuffixes = item.getFileSuffix().split(",");
+            for (String suffix : fileSuffixes) {
+                if (fileName.endsWith("." + suffix.trim().toLowerCase())) {
+                    return item.getUrlSuffix();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/main/resources/extensions/policy-template-s3os.yaml
+++ b/src/main/resources/extensions/policy-template-s3os.yaml
@@ -100,3 +100,20 @@ spec:
           label: 绑定域名（CDN域名）
           placeholder: 如不设置，那么将使用 Bucket + EndPoint 作为域名
           help: 协议头请在上方设置，此处无需以"http://"或"https://"开头，系统会自动拼接
+        - $formkit: repeater
+          name: urlSuffixes
+          label: 网址后缀
+          help: 用于对指定文件类型的网址添加后缀处理参数，优先级从上到下只取第一个匹配项
+          value: [ ]
+          min: 0
+          children:
+            - $formkit: text
+              name: fileSuffix
+              label: 文件后缀
+              placeholder: 以半角逗号分隔，例如：jpg,jpeg,png,gif
+              validation: required
+            - $formkit: text
+              name: urlSuffix
+              label: 网址后缀
+              placeholder: 例如：?imageMogr2/format/webp
+              validation: required

--- a/src/test/java/run/halo/s3os/UrlUtilsTest.java
+++ b/src/test/java/run/halo/s3os/UrlUtilsTest.java
@@ -1,5 +1,6 @@
 package run.halo.s3os;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,5 +12,39 @@ class UrlUtilsTest {
         assert UrlUtils.removeHttpPrefix(null) == null;
         assert UrlUtils.removeHttpPrefix("http://www.example.com").equals("www.example.com");
         assert UrlUtils.removeHttpPrefix("https://www.example.com").equals("www.example.com");
+    }
+
+    @Test
+    public void testFindUrlSuffix() {
+        List<S3OsProperties.urlSuffixItem> urlSuffixList = List.of(
+            new S3OsProperties.urlSuffixItem("jpg,png,gif", "?imageMogr2/format/webp"),
+            new S3OsProperties.urlSuffixItem("pdf", "?123=123"),
+            new S3OsProperties.urlSuffixItem("jpg", "?456=456")
+        );
+
+        // 测试文件名为"example.jpg"，期望匹配到"?imageMogr2/format/webp"，只匹配第一个后缀
+        String fileName1 = "example.jpg";
+        String result1 = UrlUtils.findUrlSuffix(urlSuffixList, fileName1);
+        assertEquals("?imageMogr2/format/webp", result1);
+
+        // 测试文件名为"Document.PDF"，期望匹配到"?123=123"，不区分大小写
+        String fileName2 = "Document.PDF";
+        String result2 = UrlUtils.findUrlSuffix(urlSuffixList, fileName2);
+        assertEquals("?123=123", result2);
+
+        // 测试文件名为"unknown.txt"，期望没有匹配项，返回null
+        String fileName3 = "unknown.txt";
+        String result3 = UrlUtils.findUrlSuffix(urlSuffixList, fileName3);
+        assertNull(result3);
+
+        // 测试无后缀文件名"example"，期望没有匹配项，返回null
+        String fileName4 = "example";
+        String result4 = UrlUtils.findUrlSuffix(urlSuffixList, fileName4);
+        assertNull(result4);
+
+        // 测试空文件名，期望返回null
+        String fileName5 = "";
+        String result5 = UrlUtils.findUrlSuffix(urlSuffixList, fileName5);
+        assertNull(result5);
     }
 }


### PR DESCRIPTION
增加网址后缀功能
![image](https://github.com/halo-dev/plugin-s3/assets/28662535/cd56ed01-70b0-44fc-ae40-110f7c2c1aea)

此功能在文件上传和关联文件均生效

Fix #77 
Fix #68 
```release-note
增加给指定类型的文件加上特定的网址后缀功能
```