### PR TITLE
fix: log cannot be output and log information error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,10 @@ dependencies {
     compileOnly 'run.halo.app:api'
 
     implementation platform('software.amazon.awssdk:bom:2.19.8')
-    implementation 'software.amazon.awssdk:s3'
+    implementation ('software.amazon.awssdk:s3') {
+        exclude group: 'org.slf4j'
+        exclude group: 'commons-logging'
+    }
 
     testImplementation 'run.halo.app:api'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -373,7 +373,7 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
                     // build object detail
                     .map((response) -> {
                         checkResult(response, "getMetadata");
-                        log.info("Upload object {} to bucket {} successfully",
+                        log.info("Uploaded object {} to bucket {} successfully",
                             uploadState.objectKey, properties.getBucket());
                         return new ObjectDetail(uploadState, response);
                     })

--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -216,8 +216,7 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
         var attachment = new Attachment();
         attachment.setMetadata(metadata);
         attachment.setSpec(spec);
-        log.info("Upload object {} to bucket {} successfully", objectDetail.uploadState.objectKey,
-            properties.getBucket());
+        log.info("Build attachment {} successfully", objectDetail.uploadState.objectKey);
         return attachment;
     }
 
@@ -368,6 +367,8 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
                     // build object detail
                     .map((response) -> {
                         checkResult(response, "getMetadata");
+                        log.info("Upload object {} to bucket {} successfully",
+                            uploadState.objectKey, properties.getBucket());
                         return new ObjectDetail(uploadState, response);
                     })
                     // close client

--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -222,7 +222,7 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
         var attachment = new Attachment();
         attachment.setMetadata(metadata);
         attachment.setSpec(spec);
-        log.info("Build attachment {} successfully", objectDetail.uploadState.objectKey);
+        log.info("Built attachment {} successfully", objectDetail.uploadState.objectKey);
         return attachment;
     }
 


### PR DESCRIPTION
```release-note
修复无日志输出的问题
```
fixes #100 
测试上传，关联，删除，解除关联 4种操作的日志
```
---上传---
2023-11-27T22:39:22.139+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : operation: createMultipartUpload, result: CreateMultipartUploadResponse(Bucket=test-1305034426, Key=test/image-pjcl.png, UploadId=17010959629c897f8b8c1a592b0efe300de867a1ea3e891cf04b4f95c6986470a0f30195be)
2023-11-27T22:39:22.391+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : operation: uploadPart, result: UploadPartResponse(ETag="aa84eea735192b49552fa5bf3df317fa")
2023-11-27T22:39:22.547+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : operation: completeUpload, result: CompleteMultipartUploadResponse(Location=http://test-1305034426.cos.ap-guangzhou.myqcloud.com/test/image-pjcl.png, Bucket=test-1305034426, Key=test/image-pjcl.png, ETag="afdd5ce39cf49676238fcfc879664b55-1")
2023-11-27T22:39:22.616+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : operation: getMetadata, result: HeadObjectResponse(AcceptRanges=bytes, LastModified=2023-11-27T14:39:22Z, ContentLength=1420, ETag="afdd5ce39cf49676238fcfc879664b55-1", ContentType=image/png, Metadata={})
2023-11-27T22:39:22.616+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : Upload object test/image-pjcl.png to bucket test-1305034426 successfully
2023-11-27T22:39:22.626+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : Build attachment test/image-pjcl.png successfully
2023-11-27T22:39:29.915+08:00  WARN 7 --- [or-http-epoll-1] ocalVariableTableParameterNameDiscoverer : Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: run.halo.s3os.S3LinkController
---关联---
2023-11-27T22:39:34.657+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : Build attachment test/34.txt successfully
---解除关联---
2023-11-27T22:39:39.937+08:00  INFO 7 --- [tReconciler-t-1] run.halo.s3os.S3OsAttachmentHandler      : Skip deleting object test/34.txt from S3.
---删除---
2023-11-27T22:39:44.290+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : operation: delete object, result: DeleteObjectResponse()
2023-11-27T22:39:44.291+08:00  INFO 7 --- [oundedElastic-5] run.halo.s3os.S3OsAttachmentHandler      : Delete object test/image-pjcl.png from bucket test-1305034426 successfully
```