### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.6.1-SNAPSHOT
+version=1.7.0-SNAPSHOT


### PR DESCRIPTION
```release-note
None
```
已测试2.10.0和2.11.0无问题