### PR TITLE
refactor: place the entry for the S3 link page in the side menu

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -11,9 +11,9 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@halo-dev/api-client": "^2.10.0",
-    "@halo-dev/components": "^1.9.0",
-    "@halo-dev/console-shared": "^2.10.0",
+    "@halo-dev/api-client": "^2.11.0",
+    "@halo-dev/components": "^1.10.0",
+    "@halo-dev/console-shared": "^2.11.0",
     "@tanstack/vue-query": "4.29.1",
     "axios": "^1.4.0",
     "canvas-confetti": "^1.6.0",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -6,14 +6,14 @@ settings:
 
 dependencies:
   '@halo-dev/api-client':
-    specifier: ^2.10.0
-    version: 2.10.0
+    specifier: ^2.11.0
+    version: 2.11.0
   '@halo-dev/components':
-    specifier: ^1.9.0
-    version: 1.9.0(vue-router@4.2.5)(vue@3.3.7)
+    specifier: ^1.10.0
+    version: 1.10.0(vue-router@4.2.5)(vue@3.3.7)
   '@halo-dev/console-shared':
-    specifier: ^2.10.0
-    version: 2.10.0(vue-router@4.2.5)(vue@3.3.7)
+    specifier: ^2.11.0
+    version: 2.11.0(vue-router@4.2.5)(vue@3.3.7)
   '@tanstack/vue-query':
     specifier: 4.29.1
     version: 4.29.1(vue@3.3.7)
@@ -554,12 +554,12 @@ packages:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
-  /@halo-dev/api-client@2.10.0:
-    resolution: {integrity: sha512-c1fgp+xzE1gQ7O36miWU2Oz+Uh1G4Hqs3clxLSxBD7vuvktgndZGZblNDi5morHB9UkiauAIQP0+PH9L9jwBfA==}
+  /@halo-dev/api-client@2.11.0:
+    resolution: {integrity: sha512-i3PFETsPdHYnTgk3jORu00t43/rCesmqpdZg38/Hq2AdgxhPkE7rghYGdoZRLdanvVC0HM1Axn18Zd7kdizxVA==}
     dev: false
 
-  /@halo-dev/components@1.9.0(vue-router@4.2.5)(vue@3.3.7):
-    resolution: {integrity: sha512-Rc6zK7Uno+kLqvmZkv/NIv1EUVcFzS5FR7s0ai3LHbwybFF2BNul9HEEslS3Z5a9C0M0arnvkjpUlyBmrWbfRQ==}
+  /@halo-dev/components@1.10.0(vue-router@4.2.5)(vue@3.3.7):
+    resolution: {integrity: sha512-Qg7JEkuVyTAqTjuLJHQifhMGl180yZTOX2cSueAssFCuyGZtVCcN/o5FmDtrcw8UXoV8vRwxvpixgjxFwlf/4Q==}
     peerDependencies:
       vue: ^3.3.4
       vue-router: ^4.2.4
@@ -571,13 +571,13 @@ packages:
       - '@nuxt/kit'
     dev: false
 
-  /@halo-dev/console-shared@2.10.0(vue-router@4.2.5)(vue@3.3.7):
-    resolution: {integrity: sha512-c1Ol/xIU2DZk1MWhxtuk1csD90DPvCLByQyGenLgLPX1kVe6QCodWgPG4Uz0WOE1s+rZ2W6XDV0DBXrIHCYBxg==}
+  /@halo-dev/console-shared@2.11.0(vue-router@4.2.5)(vue@3.3.7):
+    resolution: {integrity: sha512-XDyoHsueVgQOvMTDm4Fx3qKzCjXd7bI9eC0DFuw3w85Y3LQeHgrJfbXRlMRCTTZhe3kgpBOra4JjByyFFWa/Cw==}
     peerDependencies:
       vue: ^3.3.4
       vue-router: ^4.2.4
     dependencies:
-      '@halo-dev/api-client': 2.10.0
+      '@halo-dev/api-client': 2.11.0
       vue: 3.3.7(typescript@4.7.4)
       vue-router: 4.2.5(vue@3.3.7)
     dev: false

--- a/console/src/index.ts
+++ b/console/src/index.ts
@@ -1,27 +1,35 @@
-import type {Attachment} from "@halo-dev/api-client";
-import type {PluginTab} from "@halo-dev/console-shared";
-import {definePlugin} from "@halo-dev/console-shared";
+import type { Attachment } from "@halo-dev/api-client";
+import { definePlugin } from "@halo-dev/console-shared";
 import S3Link from "./views/S3Link.vue";
-import S3Unlink from "./views/S3Unlink.vue"
-import type {Ref} from "vue";
-import {markRaw} from "vue";
+import S3Unlink from "./views/S3Unlink.vue";
+import type { Ref } from "vue";
+import { markRaw } from "vue";
+import CarbonFolderDetailsReference from "~icons/carbon/folder-details-reference";
 
 export default definePlugin({
   components: {},
-  routes: [],
-  extensionPoints: {
-    "plugin:self:tabs:create": (): PluginTab[] => {
-      return [
-        {
-          id: "s3-link",
-          label: "关联S3文件",
-          // @ts-ignore
-          component: markRaw(S3Link),
-          permissions: ["plugin:s3os:link"]
+  routes: [
+    {
+      parentName: "ToolsRoot",
+      route: {
+        path: "s3-link",
+        name: "S3Link",
+        component: S3Link,
+        meta: {
+          title: "S3 关联",
+          description: "提供将 S3 存储桶中的文件关联到 Halo 中的功能。",
+          searchable: true,
+          permissions: ["plugin:s3os:link"],
+          menu: {
+            name: "S3 关联",
+            icon: markRaw(CarbonFolderDetailsReference),
+            priority: 0,
+          },
         },
-      ];
+      },
     },
-    // @ts-ignore
+  ],
+  extensionPoints: {
     "attachment:list-item:operation:create": (attachment: Ref<Attachment>) => {
       return [
         {
@@ -29,10 +37,14 @@ export default definePlugin({
           component: markRaw(S3Unlink),
           permissions: ["plugin:s3os:unlink"],
           props: {
-            "attachment": attachment,
+            attachment: attachment,
           },
-          hidden: !(attachment.value.metadata.annotations
-            && attachment.value.metadata.annotations["s3os.plugin.halo.run/object-key"])
+          hidden: !(
+            attachment.value.metadata.annotations &&
+            attachment.value.metadata.annotations[
+              "s3os.plugin.halo.run/object-key"
+            ]
+          ),
         },
       ];
     },

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: PluginS3ObjectStorage
 spec:
   enabled: true
-  requires: ">=2.10.0"
+  requires: ">=2.12.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
将 S3 关联页面放置在左侧菜单。

/kind improvement

Note: 此特性需要运行在 Halo 2.12 才生效，所以此 PR 同时修改了 requires。

<img width="1920" alt="image" src="https://github.com/halo-dev/plugin-s3/assets/21301288/a78d7837-81c2-4c50-ad19-2c40e74cbc41">

<img width="1920" alt="image" src="https://github.com/halo-dev/plugin-s3/assets/21301288/41edeed8-9ce0-40d1-82a9-1fb376a08c51">


```release-note
将 S3 关联页面放置在左侧菜单。
```