### PR TITLE
fix: Correct the formatting of Milliseconds to be a 3-digit number

### DIFF
--- a/src/main/java/run/halo/s3os/PlaceholderReplacer.java
+++ b/src/main/java/run/halo/s3os/PlaceholderReplacer.java
@@ -69,7 +69,7 @@ public class PlaceholderReplacer {
 
     private static String currentMillisecond(Map<String, String> reusableParams) {
         LocalDateTime time = LocalDateTime.parse(reusableParams.get("time"));
-        return String.valueOf(time.getNano() / 1000000);
+        return String.format("%03d", time.getNano() / 1000000);
     }
 
     private static String currentSecond(Map<String, String> reusableParams) {


### PR DESCRIPTION
```release-note
修复重命名模板中 millisecond 没有被格式化3位数的问题
```
