### PR TITLE
chore: rename displayName to S3 对象存储

### DIFF
--- a/src/main/resources/extensions/policy-template-s3os.yaml
+++ b/src/main/resources/extensions/policy-template-s3os.yaml
@@ -3,7 +3,7 @@ kind: PolicyTemplate
 metadata:
   name: s3os
 spec:
-  displayName: S3 Object Storage
+  displayName: S3 对象存储
   settingName: s3os-policy-template-setting
 ---
 apiVersion: v1alpha1


### PR DESCRIPTION
在 Halo 完成动态数据的 i18n 之前，使用中文描述存储策略名称。

/kind improvement

<img width="821" alt="image" src="https://github.com/halo-dev/plugin-s3/assets/21301288/bc5fd32c-f7fc-43de-8bc4-cdbdd7e940d6">

```release-note
修改存储策略名称为中文显示。
```