### PR TITLE
Fix original file name being incorrectly replaced

### DIFF
--- a/src/main/java/run/halo/s3os/FilePathUtils.java
+++ b/src/main/java/run/halo/s3os/FilePathUtils.java
@@ -6,6 +6,6 @@ import lombok.experimental.UtilityClass;
 public class FilePathUtils {
 
     public static String getFilePathByPlaceholder(String filePath) {
-        return PlaceholderReplacer.replacePlaceholders(filePath, "");
+        return PlaceholderReplacer.replacePlaceholders(filePath, null);
     }
 }


### PR DESCRIPTION
```release-note
修复上传目录中 ${origin-filename} 占位符被错误替换为空字符串的问题
```