### PR TITLE
improve usage tips in settings page

### DIFF
--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -7,8 +7,5 @@ spec:
     - group: basic
       label: 使用提示
       formSchema:
-        - $formkit: text
-          help: 请前往 “附件 - 存储策略” 添加策略
-          label: 此处不用设置，请前往 “附件 - 存储策略” 添加策略
-          name: text
-          placeholder: 此处不用设置，请前往 “附件 - 存储策略” 添加策略
+        - $el: p
+          children: 请前往 “附件 - 存储策略” 添加策略


### PR DESCRIPTION
使用占位组件在设置页面展示信息并不恰当，并且此项目作为存储插件的 Example 工程易误导其他开发者。

调整为利用 FormKit `el` 特性实现。

问题背景：https://github.com/halo-dev/halo/issues/5802

**Preview - old**
<img width="373" alt="image" src="https://github.com/halo-dev/plugin-s3/assets/10266066/ac4aaede-6377-459f-a866-9bfe132906af">

**Preview - new**
<img width="373" alt="image" src="https://github.com/halo-dev/plugin-s3/assets/10266066/f884417c-045a-4396-84be-633d18ae36c9">

```release-note
优化调整提示的提示
```