### PR TITLE
Hide the permission of the verification interface

### DIFF
--- a/src/main/resources/extensions/s3os-role-template.yaml
+++ b/src/main/resources/extensions/s3os-role-template.yaml
@@ -46,6 +46,7 @@ metadata:
   name: role-template-s3os-policy-config-validation
   labels:
     halo.run/role-template: "true"
+    halo.run/hidden: "true"
     rbac.authorization.halo.run/aggregate-to-role-template-manage-configmaps: "true"
 rules:
   - apiGroups: ["s3os.halo.run"]


### PR DESCRIPTION
fixes https://github.com/halo-dev/plugin-s3/issues/146
```release-note
在角色创建中隐藏配置校验接口的权限
```