### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/src/main/java/run/halo/s3os/S3OsPlugin.java
+++ b/src/main/java/run/halo/s3os/S3OsPlugin.java
@@ -1,8 +1,8 @@
 package run.halo.s3os;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 /**
  * @author johnniang
@@ -11,8 +11,8 @@ import run.halo.app.plugin.BasePlugin;
 @Component
 public class S3OsPlugin extends BasePlugin {
 
-    public S3OsPlugin(PluginWrapper wrapper) {
-        super(wrapper);
+    public S3OsPlugin(PluginContext pluginContext) {
+        super(pluginContext);
     }
 
     @Override


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用，Halo 2.18.0 版本后将不在支持从 BasePlugin 中获取 PluginWrapper ，也不再支持依赖注入 PluginWrapper，使用 PluginContext 代替

see also https://github.com/halo-dev/halo/pull/6243 for more details

```release-note
None
```