### PR TITLE
chore: update requires to 2.20.0

### DIFF
--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: PluginS3ObjectStorage
 spec:
   enabled: true
-  requires: ">=2.19.0"
+  requires: ">=2.20.0"
   author:
     name: Halo
     website: https://github.com/halo-dev


### PR DESCRIPTION
### What this PR does?
将 requires 改动到 2.20.0
目前 Halo 2.20.0 已经发布，此 https://github.com/halo-dev/plugin-s3/pull/167 功能需要在 2.20.0 才能完整工作，因此升级到此版本后准备发版

```release-note
None
```