### PR TITLE
feat: add custom User-Agent configuration support for S3 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@
 * **加随机字母后缀：** 如遇重名，会在文件名后加上4位的随机字母后缀，例如`image.png`会变成`image_abcd.png`。
 * **报错不上传** 如遇重名，会放弃上传，并在用户界面提示 Duplicate filename 错误。
 
+### 自定义User-Agent
+可选配置项，仅当您的S3服务提供商要求校验客户端UA时填写，默认留空不影响任何原有功能。
+
+> 例如中国科技云数据胶囊要求密钥必须绑定应用，绑定Rclone应用后此处需要填写`rclone/v1.67.0`才能正常访问。
+
 ## 部分对象存储服务商兼容性
 
 |服务商|文档|兼容访问风格|兼容性|
@@ -149,8 +154,9 @@
 |Cloudflare|<https://developers.cloudflare.com/r2/data-access/s3-api/>|Virtual Hosted Style / <br>Path Style|✅|
 | Oracle Cloud |<https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm>|Virtual Hosted Style / <br>Path Style|✅|
 |又拍云|<https://help.upyun.com/knowledge-base/aws-s3%e5%85%bc%e5%ae%b9/>|Virtual Hosted Style / <br>Path Style|✅|
-|自建minio|\-|Path Style|✅|
+|自建minio|\\-|Path Style|✅|
 |华为云|文档未说明是否兼容，工单反馈不保证兼容性，实际测试可以使用|Virtual Hosted Style|❓|
+|中国科技云数据胶囊|<https://www.cstcloud.cn/product/datacapsule>|Path Style|✅|
 |Ucloud|只支持 8MB 大小的分片，本插件暂不支持<br><https://docs.ucloud.cn/ufile/s3/s3_introduction>|\-|❌|
 
 ## 开发环境

--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@
 * **加随机字母后缀：** 如遇重名，会在文件名后加上4位的随机字母后缀，例如`image.png`会变成`image_abcd.png`。
 * **报错不上传** 如遇重名，会放弃上传，并在用户界面提示 Duplicate filename 错误。
 
-### 自定义User-Agent
-可选配置项，仅当您的S3服务提供商要求校验客户端UA时填写，默认留空不影响任何原有功能。
+### 自定义 User-Agent
 
-> 例如中国科技云数据胶囊要求密钥必须绑定应用，绑定Rclone应用后此处需要填写`rclone/v1.67.0`才能正常访问。
+可选配置项，仅当您的 S3 服务提供商要求校验客户端 UA 时填写，默认留空不影响任何原有功能。
+
+> 例如中国科技云数据胶囊要求密钥必须绑定应用，绑定 Rclone 应用后此处需要填写 `rclone/v1.67.0` 才能正常访问。
 
 ## 部分对象存储服务商兼容性
 
@@ -154,7 +155,7 @@
 |Cloudflare|<https://developers.cloudflare.com/r2/data-access/s3-api/>|Virtual Hosted Style / <br>Path Style|✅|
 | Oracle Cloud |<https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm>|Virtual Hosted Style / <br>Path Style|✅|
 |又拍云|<https://help.upyun.com/knowledge-base/aws-s3%e5%85%bc%e5%ae%b9/>|Virtual Hosted Style / <br>Path Style|✅|
-|自建minio|\\-|Path Style|✅|
+|自建minio|\-|Path Style|✅|
 |华为云|文档未说明是否兼容，工单反馈不保证兼容性，实际测试可以使用|Virtual Hosted Style|❓|
 |中国科技云数据胶囊|<https://www.cstcloud.cn/product/datacapsule>|Path Style|✅|
 |Ucloud|只支持 8MB 大小的分片，本插件暂不支持<br><https://docs.ucloud.cn/ufile/s3/s3_introduction>|\-|❌|

--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -318,7 +318,8 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
                 .pathStyleAccessEnabled(properties.getEnablePathStyleAccess())
                 .build());
         if (StringUtils.isNotBlank(properties.getUserAgent())) {
-            builder.overrideConfiguration(config -> config.putHeader("User-Agent", properties.getUserAgent()));
+            builder.overrideConfiguration(config ->
+                config.putHeader("User-Agent", properties.getUserAgent()));
         }
         return builder.build();
     }

--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -307,7 +307,7 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
     }
 
     S3Client buildS3Client(S3OsProperties properties) {
-        return S3Client.builder()
+        var builder = S3Client.builder()
             .region(Region.of(properties.getRegion()))
             .endpointOverride(
                 URI.create(properties.getEndpointProtocol() + "://" + properties.getEndpoint()))
@@ -316,8 +316,11 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
             .serviceConfiguration(S3Configuration.builder()
                 .chunkedEncodingEnabled(false)
                 .pathStyleAccessEnabled(properties.getEnablePathStyleAccess())
-                .build())
-            .build();
+                .build());
+        if (StringUtils.isNotBlank(properties.getUserAgent())) {
+            builder.overrideConfiguration(config -> config.putHeader("User-Agent", properties.getUserAgent()));
+        }
+        return builder.build();
     }
 
     private S3Presigner buildS3Presigner(S3OsProperties properties) {

--- a/src/main/java/run/halo/s3os/S3OsProperties.java
+++ b/src/main/java/run/halo/s3os/S3OsProperties.java
@@ -48,6 +48,12 @@ public class S3OsProperties {
 
     private String region = "Auto";
 
+    /**
+     * Custom User-Agent header for S3 requests, optional.
+     * Useful for services that validate client application binding like CSTCloud.
+     */
+    private String userAgent = "";
+
     private List<urlSuffixItem> urlSuffixes;
 
     private String thumbnailParamPattern;

--- a/src/main/resources/extensions/policy-template-s3os.yaml
+++ b/src/main/resources/extensions/policy-template-s3os.yaml
@@ -72,7 +72,7 @@ spec:
               name: userAgent
               label: 自定义 User-Agent
               placeholder: 如 Rclone、S3Drive 等，留空则使用默认值
-              help: 部分对象存储服务（如中国科技云数据胶囊）会校验请求客户端类型，绑定 Rclone 应用后此处填`rclone/v1.67.0` 即可正常使用
+              help: 部分对象存储服务（如中国科技云数据胶囊）会校验请求客户端类型，绑定 Rclone 应用后此处填 `rclone/v1.67.0` 即可正常使用
             - $formkit: text
               name: location
               label: 上传目录

--- a/src/main/resources/extensions/policy-template-s3os.yaml
+++ b/src/main/resources/extensions/policy-template-s3os.yaml
@@ -50,9 +50,9 @@ spec:
             - $formkit: text
               name: endpoint
               label: EndPoint
-              placeholder: 请填写不带 bucket name 的 Endpoint
+              placeholder: 请填写不带bucket-name的Endpoint
               validation: required
-              help: 协议头请在上方设置，此处无需以 "http://" 或"https://"开头，系统会自动拼接
+              help: 协议头请在上方设置，此处无需以"http://"或"https://"开头，系统会自动拼接
             - $formkit: password
               name: accessKey
               label: Access Key ID
@@ -69,14 +69,17 @@ spec:
               placeholder: 如不填写，则默认为 Auto
               help: 若 Region 为 Auto 无法使用，才需要填写对应 Region，Cloudflare R2 需要填写均为小写字母的 auto
             - $formkit: text
+              name: userAgent
+              label: 自定义User-Agent
+              placeholder: 如Rclone、S3Drive等，留空则使用默认值
+              help: 部分对象存储服务（如中国科技云数据胶囊）会校验请求客户端类型，绑定Rclone应用后此处填`rclone/v1.67.0`即可正常使用
+            - $formkit: text
               name: location
               label: 上传目录
               placeholder: 如不填写，则默认上传到根目录
               help: 支持的占位符请查阅：https://github.com/halo-dev/plugin-s3#上传目录
             - $formkit: select
               name: randomFilenameMode
-              key: randomFilenameMode
-              id: randomFilenameMode
               label: 上传时重命名文件方式
               options:
                 - label: 保留原文件名
@@ -102,13 +105,13 @@ spec:
               label: 随机字母长度
               min: 4
               max: 16
-              if: "$get(randomFilenameMode).value == 'dateWithString' || $get(randomFilenameMode).value == 'datetimeWithString' || $get(randomFilenameMode).value == 'withString' || $get(randomFilenameMode).value == 'string'"
+              if: "$randomFilenameMode == 'dateWithString' || $randomFilenameMode == 'datetimeWithString' || $randomFilenameMode == 'withString' || $randomFilenameMode == 'string'"
               help: 支持4~16位, 默认为8位
             - $formkit: text
               name: customTemplate
               key: customTemplate
               label: 自定义文件名模板
-              if: "$get(randomFilenameMode).value == 'custom'"
+              if: "$randomFilenameMode == 'custom'"
               value: "${origin-filename}"
               help: 支持的占位符请查阅：https://github.com/halo-dev/plugin-s3#自定义文件名模板
             - $formkit: select
@@ -135,7 +138,7 @@ spec:
               name: domain
               label: 绑定域名（CDN域名）
               placeholder: 如不设置，那么将使用 Bucket + EndPoint 作为域名
-              help: 协议头请在上方设置，此处无需以 "http://" 或 "https://" 开头，系统会自动拼接
+              help: 协议头请在上方设置，此处无需以"http://"或"https://"开头，系统会自动拼接
             - $formkit: repeater
               name: urlSuffixes
               label: 网址后缀

--- a/src/main/resources/extensions/policy-template-s3os.yaml
+++ b/src/main/resources/extensions/policy-template-s3os.yaml
@@ -50,9 +50,9 @@ spec:
             - $formkit: text
               name: endpoint
               label: EndPoint
-              placeholder: 请填写不带bucket-name的Endpoint
+              placeholder: 请填写不带 bucket name 的 Endpoint
               validation: required
-              help: 协议头请在上方设置，此处无需以"http://"或"https://"开头，系统会自动拼接
+              help: 协议头请在上方设置，此处无需以 "http://" 或"https://"开头，系统会自动拼接
             - $formkit: password
               name: accessKey
               label: Access Key ID
@@ -70,9 +70,9 @@ spec:
               help: 若 Region 为 Auto 无法使用，才需要填写对应 Region，Cloudflare R2 需要填写均为小写字母的 auto
             - $formkit: text
               name: userAgent
-              label: 自定义User-Agent
-              placeholder: 如Rclone、S3Drive等，留空则使用默认值
-              help: 部分对象存储服务（如中国科技云数据胶囊）会校验请求客户端类型，绑定Rclone应用后此处填`rclone/v1.67.0`即可正常使用
+              label: 自定义 User-Agent
+              placeholder: 如 Rclone、S3Drive 等，留空则使用默认值
+              help: 部分对象存储服务（如中国科技云数据胶囊）会校验请求客户端类型，绑定 Rclone 应用后此处填`rclone/v1.67.0` 即可正常使用
             - $formkit: text
               name: location
               label: 上传目录
@@ -80,6 +80,8 @@ spec:
               help: 支持的占位符请查阅：https://github.com/halo-dev/plugin-s3#上传目录
             - $formkit: select
               name: randomFilenameMode
+              key: randomFilenameMode
+              id: randomFilenameMode
               label: 上传时重命名文件方式
               options:
                 - label: 保留原文件名
@@ -105,13 +107,13 @@ spec:
               label: 随机字母长度
               min: 4
               max: 16
-              if: "$randomFilenameMode == 'dateWithString' || $randomFilenameMode == 'datetimeWithString' || $randomFilenameMode == 'withString' || $randomFilenameMode == 'string'"
+              if: "$get(randomFilenameMode).value == 'dateWithString' || $get(randomFilenameMode).value == 'datetimeWithString' || $get(randomFilenameMode).value == 'withString' || $get(randomFilenameMode).value == 'string'"
               help: 支持4~16位, 默认为8位
             - $formkit: text
               name: customTemplate
               key: customTemplate
               label: 自定义文件名模板
-              if: "$randomFilenameMode == 'custom'"
+              if: "$get(randomFilenameMode).value == 'custom'"
               value: "${origin-filename}"
               help: 支持的占位符请查阅：https://github.com/halo-dev/plugin-s3#自定义文件名模板
             - $formkit: select
@@ -138,7 +140,7 @@ spec:
               name: domain
               label: 绑定域名（CDN域名）
               placeholder: 如不设置，那么将使用 Bucket + EndPoint 作为域名
-              help: 协议头请在上方设置，此处无需以"http://"或"https://"开头，系统会自动拼接
+              help: 协议头请在上方设置，此处无需以 "http://" 或 "https://" 开头，系统会自动拼接
             - $formkit: repeater
               name: urlSuffixes
               label: 网址后缀


### PR DESCRIPTION
新增可选自定义User-Agent配置项，默认留空，不影响任何原有功能
- 新增userAgent字段到S3OsProperties，默认空字符串
- 配置表单新增自定义UA输入框，附带中国科技云适配提示
- S3Client构建逻辑添加UA头注入，仅当配置非空时生效
- README文档更新：新增UA配置说明、中国科技云兼容性条目
- 完全向后兼容，默认行为和原版完全一致

Fixes https://github.com/halo-dev/plugin-s3/issues/209

```release-note
支持自定义 User Agent，解决部分厂商的兼容性问题
```