### PR TITLE
Disable optional S3 checksum headers

### DIFF
--- a/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
+++ b/src/main/java/run/halo/s3os/S3OsAttachmentHandler.java
@@ -32,6 +32,7 @@ import run.halo.app.extension.Metadata;
 import run.halo.app.extension.MetadataUtil;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.awscore.presigner.SdkPresigner;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpResponse;
@@ -309,6 +310,7 @@ public class S3OsAttachmentHandler implements AttachmentHandler {
     S3Client buildS3Client(S3OsProperties properties) {
         var builder = S3Client.builder()
             .region(Region.of(properties.getRegion()))
+            .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
             .endpointOverride(
                 URI.create(properties.getEndpointProtocol() + "://" + properties.getEndpoint()))
             .credentialsProvider(() -> AwsBasicCredentials.create(properties.getAccessKey(),

--- a/src/test/java/run/halo/s3os/S3OsAttachmentHandlerTest.java
+++ b/src/test/java/run/halo/s3os/S3OsAttachmentHandlerTest.java
@@ -1,5 +1,7 @@
 package run.halo.s3os;
 
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -11,11 +13,15 @@ import run.halo.app.core.extension.attachment.Attachment;
 import run.halo.app.core.extension.attachment.Policy;
 import run.halo.app.extension.ConfigMap;
 import run.halo.app.extension.Metadata;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,6 +53,47 @@ class S3OsAttachmentHandlerTest {
 
         // policy is null
         assertFalse(handler.shouldHandle(null));
+    }
+
+    @Test
+    void buildS3ClientShouldNotSendOptionalChecksumHeadersForUploadPart() throws Exception {
+        var headersRef = new AtomicReference<Headers>();
+        var server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/", exchange -> {
+            headersRef.set(exchange.getRequestHeaders());
+            exchange.getRequestBody().transferTo(java.io.OutputStream.nullOutputStream());
+            exchange.getResponseHeaders().add("ETag", "\"etag\"");
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+        try {
+            var properties = new S3OsProperties();
+            properties.setBucket("bucket");
+            properties.setEndpointProtocol(S3OsProperties.Protocol.http);
+            properties.setEndpoint("localhost:" + server.getAddress().getPort());
+            properties.setAccessKey("access-key");
+            properties.setAccessSecret("secret-key");
+            properties.setRegion("us-east-1");
+            properties.setEnablePathStyleAccess(true);
+
+            try (var client = handler.buildS3Client(properties)) {
+                client.uploadPart(UploadPartRequest.builder()
+                        .bucket(properties.getBucket())
+                        .key("halo.txt")
+                        .uploadId("upload-id")
+                        .partNumber(1)
+                        .contentLength(5L)
+                        .build(),
+                    RequestBody.fromString("hello"));
+            }
+
+            var headers = headersRef.get();
+            assertFalse(hasHeader(headers, "x-amz-sdk-checksum-algorithm"));
+            assertFalse(hasHeader(headers, "x-amz-checksum-crc32"));
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
@@ -207,6 +254,10 @@ class S3OsAttachmentHandlerTest {
         attachment.setStatus(new Attachment.AttachmentStatus());
         attachment.getStatus().setPermalink(permalink);
         return attachment;
+    }
+
+    private static boolean hasHeader(Headers headers, String name) {
+        return headers.keySet().stream().anyMatch(name::equalsIgnoreCase);
     }
 
 }


### PR DESCRIPTION
## Summary
- Configure the S3 client to use `RequestChecksumCalculation.WHEN_REQUIRED`
- Keep presigned URL generation unchanged
- Add a regression test that verifies `uploadPart` no longer sends optional SDK checksum headers

## Rationale
AWS SDK for Java v2 can send flexible checksum headers such as `x-amz-sdk-checksum-algorithm` and `x-amz-checksum-crc32` for multipart uploads. Some S3-compatible services reject those optional headers, causing otherwise valid uploads to fail.

## Testing
- `./gradlew test --tests run.halo.s3os.S3OsAttachmentHandlerTest`
- `./gradlew test`
- `git diff --check`